### PR TITLE
Zeigt nur die Felder an, die gültig sind

### DIFF
--- a/assets/ycom_backend.js
+++ b/assets/ycom_backend.js
@@ -1,0 +1,26 @@
+// hide group fields in article edit page if not needed
+function change_ycom_fields() {
+	if($('#yform-ycom_auth-perm-field-0 option:selected').val() != 1) {
+		$('#yform-ycom_auth-perm-field-1').closest('.form-group').hide();
+		$('#yform-ycom_auth-perm-field-2').closest('.form-group').hide();
+	}
+	else {
+		$('#yform-ycom_auth-perm-field-1').closest('.form-group').show();
+		if($('#yform-ycom_auth-perm-field-1 option:selected').val() == 1 || $('#yform-ycom_auth-perm-field-1 option:selected').val() == 2) {
+			$('#yform-ycom_auth-perm-field-2').closest('.form-group').show();
+		}
+		else {
+			$('#yform-ycom_auth-perm-field-2').closest('.form-group').hide();
+		}
+	}
+}
+
+$(document).on('rex:ready', function () {
+	change_ycom_fields();	
+	$('#yform-ycom_auth-perm-field-0').on('change', function() {
+		change_ycom_fields();
+	});
+	$('#yform-ycom_auth-perm-field-1').on('change', function() {
+		change_ycom_fields();
+	});
+});

--- a/boot.php
+++ b/boot.php
@@ -23,41 +23,5 @@ rex_ycom::addTable('rex_ycom_user');
 rex_yform_manager_dataset::setModelClass('rex_ycom_user', rex_ycom_user::class);
 
 if(rex::isBackend() && rex_url::currentBackendPage() == "index.php?page=content/edit") {
-	rex_extension::register('OUTPUT_FILTER', 'append_ycom_script');
-}
-
-/**
- * Adds JS to media pool, showing goup field only if needed
- * @param rex_extension_point $ep Redaxo extension point
- */
-function append_ycom_script(rex_extension_point $ep) {
-	// Insert before </body> element
-	$insert_body = "<script type='text/javascript'>". PHP_EOL
-		."function change_ycom_fields() {". PHP_EOL
-		."	if($('#yform-ycom_auth-perm-field-0 option:selected').val() != 1) {". PHP_EOL
-		."		$('#yform-ycom_auth-perm-field-1').closest('.form-group').hide();". PHP_EOL
-		."		$('#yform-ycom_auth-perm-field-2').closest('.form-group').hide();". PHP_EOL
-		."	}". PHP_EOL
-		."	else {". PHP_EOL
-		."		$('#yform-ycom_auth-perm-field-1').closest('.form-group').show();". PHP_EOL
-		."		if($('#yform-ycom_auth-perm-field-1 option:selected').val() == 1 || $('#yform-ycom_auth-perm-field-1 option:selected').val() == 2) {". PHP_EOL
-		."			$('#yform-ycom_auth-perm-field-2').closest('.form-group').show();". PHP_EOL
-		."		}". PHP_EOL
-		."		else {". PHP_EOL
-		."			$('#yform-ycom_auth-perm-field-2').closest('.form-group').hide();". PHP_EOL
-		."		}". PHP_EOL
-		."	}". PHP_EOL
-		."}". PHP_EOL
-
-		."$(document).on('rex:ready', function () {". PHP_EOL
-		."	change_ycom_fields();". PHP_EOL	
-		."	$('#yform-ycom_auth-perm-field-0').on('change', function() {". PHP_EOL
-		."		change_ycom_fields();". PHP_EOL
-		."	});". PHP_EOL
-		."	$('#yform-ycom_auth-perm-field-1').on('change', function() {". PHP_EOL
-		."		change_ycom_fields();". PHP_EOL
-		."	});". PHP_EOL
-		."});". PHP_EOL
-		."</script>";
-	$ep->setSubject(str_replace('</body>', $insert_body .'</body>', $ep->getSubject()));
+	rex_view::addJsFile($this->getAssetsUrl('ycom_backend.js'));
 }

--- a/boot.php
+++ b/boot.php
@@ -21,3 +21,60 @@ if (rex::isBackend()) {
 
 rex_ycom::addTable('rex_ycom_user');
 rex_yform_manager_dataset::setModelClass('rex_ycom_user', rex_ycom_user::class);
+
+if(rex::isBackend() && rex_url::currentBackendPage() == "index.php?page=content/edit") {
+	rex_extension::register('OUTPUT_FILTER', 'append_ycom_script');
+}
+
+/**
+ * Adds JS to media pool, showing goup field only if needed
+ * @param rex_extension_point $ep Redaxo extension point
+ */
+function append_ycom_script(rex_extension_point $ep) {
+	// Insert befor </body> element
+	$insert_body = "<script type='text/javascript'>". PHP_EOL
+	."function change_ycom_fields() {". PHP_EOL
+	."	if($('#yform-ycom_auth-perm-field-0 option:selected').val() != 1) {". PHP_EOL
+	."		$('#yform-ycom_auth-perm-field-1').closest('.form-group').hide();". PHP_EOL
+	."		$('#yform-ycom_auth-perm-field-2').closest('.form-group').hide();". PHP_EOL
+	."	}". PHP_EOL
+	."	else {". PHP_EOL
+	."		$('#yform-ycom_auth-perm-field-1').closest('.form-group').show();". PHP_EOL
+	."		if($('#yform-ycom_auth-perm-field-1 option:selected').val() == 1 || $('#yform-ycom_auth-perm-field-1 option:selected').val() == 2) {". PHP_EOL
+	."			$('#yform-ycom_auth-perm-field-2').closest('.form-group').show();". PHP_EOL
+	."		}". PHP_EOL
+	."		else {". PHP_EOL
+	."			$('#yform-ycom_auth-perm-field-2').closest('.form-group').hide();". PHP_EOL
+	."		}". PHP_EOL
+	."	}". PHP_EOL
+	."}". PHP_EOL
+
+	// This dirty hack is needed due to ajax breaks event listener
+	."function change_ycom_fields_rebinder() {". PHP_EOL
+	."	$('#yform-ycom_auth-perm-field-0').on('change', function() {". PHP_EOL
+	."		change_ycom_fields();". PHP_EOL
+	."	});". PHP_EOL
+	."	$('#yform-ycom_auth-perm-field-1').on('change', function() {". PHP_EOL
+	."		change_ycom_fields();". PHP_EOL
+	."	});". PHP_EOL
+	."	change_ycom_fields();". PHP_EOL
+	."	setTimeout(change_ycom_fields_rebinder, 2000);". PHP_EOL
+	."}". PHP_EOL		
+
+	// hide groups if not needed on load
+	."jQuery(document).ready(function($) {". PHP_EOL
+	."	change_ycom_fields();". PHP_EOL
+	."	change_ycom_fields_rebinder()". PHP_EOL		
+	."});". PHP_EOL
+	
+	// hide or show group select if needed / not needed
+	."$('#yform-ycom_auth-perm-field-0').on('change', function() {". PHP_EOL
+	."	change_ycom_fields();". PHP_EOL
+	."});". PHP_EOL
+	."$('#yform-ycom_auth-perm-field-1').on('change', function() {". PHP_EOL
+	."	change_ycom_fields();". PHP_EOL
+	."});". PHP_EOL
+
+	."</script>";
+	$ep->setSubject(str_replace('</body>', $insert_body .'</body>', $ep->getSubject()));
+}

--- a/boot.php
+++ b/boot.php
@@ -31,7 +31,7 @@ if(rex::isBackend() && rex_url::currentBackendPage() == "index.php?page=content/
  * @param rex_extension_point $ep Redaxo extension point
  */
 function append_ycom_script(rex_extension_point $ep) {
-	// Insert befor </body> element
+	// Insert before </body> element
 	$insert_body = "<script type='text/javascript'>". PHP_EOL
 	."function change_ycom_fields() {". PHP_EOL
 	."	if($('#yform-ycom_auth-perm-field-0 option:selected').val() != 1) {". PHP_EOL

--- a/boot.php
+++ b/boot.php
@@ -33,48 +33,31 @@ if(rex::isBackend() && rex_url::currentBackendPage() == "index.php?page=content/
 function append_ycom_script(rex_extension_point $ep) {
 	// Insert before </body> element
 	$insert_body = "<script type='text/javascript'>". PHP_EOL
-	."function change_ycom_fields() {". PHP_EOL
-	."	if($('#yform-ycom_auth-perm-field-0 option:selected').val() != 1) {". PHP_EOL
-	."		$('#yform-ycom_auth-perm-field-1').closest('.form-group').hide();". PHP_EOL
-	."		$('#yform-ycom_auth-perm-field-2').closest('.form-group').hide();". PHP_EOL
-	."	}". PHP_EOL
-	."	else {". PHP_EOL
-	."		$('#yform-ycom_auth-perm-field-1').closest('.form-group').show();". PHP_EOL
-	."		if($('#yform-ycom_auth-perm-field-1 option:selected').val() == 1 || $('#yform-ycom_auth-perm-field-1 option:selected').val() == 2) {". PHP_EOL
-	."			$('#yform-ycom_auth-perm-field-2').closest('.form-group').show();". PHP_EOL
-	."		}". PHP_EOL
-	."		else {". PHP_EOL
-	."			$('#yform-ycom_auth-perm-field-2').closest('.form-group').hide();". PHP_EOL
-	."		}". PHP_EOL
-	."	}". PHP_EOL
-	."}". PHP_EOL
+		."function change_ycom_fields() {". PHP_EOL
+		."	if($('#yform-ycom_auth-perm-field-0 option:selected').val() != 1) {". PHP_EOL
+		."		$('#yform-ycom_auth-perm-field-1').closest('.form-group').hide();". PHP_EOL
+		."		$('#yform-ycom_auth-perm-field-2').closest('.form-group').hide();". PHP_EOL
+		."	}". PHP_EOL
+		."	else {". PHP_EOL
+		."		$('#yform-ycom_auth-perm-field-1').closest('.form-group').show();". PHP_EOL
+		."		if($('#yform-ycom_auth-perm-field-1 option:selected').val() == 1 || $('#yform-ycom_auth-perm-field-1 option:selected').val() == 2) {". PHP_EOL
+		."			$('#yform-ycom_auth-perm-field-2').closest('.form-group').show();". PHP_EOL
+		."		}". PHP_EOL
+		."		else {". PHP_EOL
+		."			$('#yform-ycom_auth-perm-field-2').closest('.form-group').hide();". PHP_EOL
+		."		}". PHP_EOL
+		."	}". PHP_EOL
+		."}". PHP_EOL
 
-	// This dirty hack is needed due to ajax breaks event listener
-	."function change_ycom_fields_rebinder() {". PHP_EOL
-	."	$('#yform-ycom_auth-perm-field-0').on('change', function() {". PHP_EOL
-	."		change_ycom_fields();". PHP_EOL
-	."	});". PHP_EOL
-	."	$('#yform-ycom_auth-perm-field-1').on('change', function() {". PHP_EOL
-	."		change_ycom_fields();". PHP_EOL
-	."	});". PHP_EOL
-	."	change_ycom_fields();". PHP_EOL
-	."	setTimeout(change_ycom_fields_rebinder, 2000);". PHP_EOL
-	."}". PHP_EOL		
-
-	// hide groups if not needed on load
-	."jQuery(document).ready(function($) {". PHP_EOL
-	."	change_ycom_fields();". PHP_EOL
-	."	change_ycom_fields_rebinder()". PHP_EOL		
-	."});". PHP_EOL
-	
-	// hide or show group select if needed / not needed
-	."$('#yform-ycom_auth-perm-field-0').on('change', function() {". PHP_EOL
-	."	change_ycom_fields();". PHP_EOL
-	."});". PHP_EOL
-	."$('#yform-ycom_auth-perm-field-1').on('change', function() {". PHP_EOL
-	."	change_ycom_fields();". PHP_EOL
-	."});". PHP_EOL
-
-	."</script>";
+		."$(document).on('rex:ready', function () {". PHP_EOL
+		."	change_ycom_fields();". PHP_EOL	
+		."	$('#yform-ycom_auth-perm-field-0').on('change', function() {". PHP_EOL
+		."		change_ycom_fields();". PHP_EOL
+		."	});". PHP_EOL
+		."	$('#yform-ycom_auth-perm-field-1').on('change', function() {". PHP_EOL
+		."		change_ycom_fields();". PHP_EOL
+		."	});". PHP_EOL
+		."});". PHP_EOL
+		."</script>";
 	$ep->setSubject(str_replace('</body>', $insert_body .'</body>', $ep->getSubject()));
 }


### PR DESCRIPTION
Nur wenn im Feld Zugriffsrechte "Zugriff für eingeloggte User" ausgewählt ist, braucht es das Feld "Gruppenrechte".
Nur wenn im Feld "Gruppenrechte" "Muss in jeder Gruppe" oder "Muss in einer Gruppe" ausgewählt ist, braucht es das Feld Gruppen.

Diese Änderung fügt ein JavaScript beim Editieren eines Artikels hinzu, das die Felder "Gruppenrechte" und "Gruppen" ausblendet, wenn sie nicht benötigt werden. Leider wird beim Speichern der Rechte AJAX verwendet. Dadurch verlieren die Elemente beim Speichern ihre jQuery Event Listener, weshalb auch noch die Funktion change_ycom_fields_rebinder() hinzugefügt wird, die die Werte der Felder jede 2 Sekunde checkt, gegebenfalls Felder ausblendet und die Listener wieder hinzufügt.