### PR TITLE
auth rule interval fix

### DIFF
--- a/plugins/auth/lib/ycom_auth_rules.php
+++ b/plugins/auth/lib/ycom_auth_rules.php
@@ -70,7 +70,7 @@ class rex_ycom_auth_rules
                 }
                 break;
             case 'interval':
-                if ($loginTries % $rule['tries'] != 0) {
+                if ($loginTries ==0 || $loginTries % $rule['tries'] != 0) {
                     return true;
                 }
                 break;


### PR DESCRIPTION
Bin durch einen Fehler erst nach Diagnose auf issue #169 gestoßen.
Eingestellt war eine Regel vom Typ "interval". Anmeldung war nicht möglich.
Jetzt hatte ich geprüft und habe das Problem lokalisiert.

Im Code ergibt `$loginTries % $rule['tries']` zu Beginn 0, da (0 mod x) = 0 ist. 
Es wird also beim ersten Loginversuch nicht true zurückgegeben. 
Denke das ist nicht sinnvoll. 