### PR TITLE
Code ist fehlerhaft, statt "id" muss es "email" lauten

### DIFF
--- a/pages/main.manual_form_register_proof.inc
+++ b/pages/main.manual_form_register_proof.inc
@@ -5,7 +5,7 @@ objparams|submit_btn_show|0
 objparams|send|1
 objparams|csrf_protection|0
 
-validate|ycom_auth_login|activation_key=rex_ycom_activation_key,id=rex_ycom_id|status=0|Zugang wurde bereits bestätigt oder ist schon fehlgeschlagen|status
+validate|ycom_auth_login|activation_key=rex_ycom_activation_key,email=rex_ycom_id|status=0|Zugang wurde bereits bestätigt oder ist schon fehlgeschlagen|status
 
 action|ycom_auth_db|update
 action|html|<b>Vielen Dank, Sie sind nun eingeloggt und haben Ihre E-Mail bestätigt</b>


### PR DESCRIPTION
Registrierungsbestätigung: Formularcode in Anleitung falsch