### PR TITLE
PHP 7.2 fix countable

### DIFF
--- a/plugins/auth/lib/yform/value/ycom_auth_password.php
+++ b/plugins/auth/lib/yform/value/ycom_auth_password.php
@@ -6,7 +6,7 @@ class rex_yform_value_ycom_auth_password extends rex_yform_value_abstract
     {
 
         $rules = json_decode($this->getElement('rules'), true);
-        if (count($rules) == 0) {
+        if (!$rules || count($rules) == 0) {
             $rules = json_decode(rex_yform_validate_password_policy::PASSWORD_POLICY_DEFAULT_RULES, true);
         }
 


### PR DESCRIPTION
Verhindert, dass eine Fehlermeldung in 7.2 auftritt, wenn keine Passwort-Regeln vorliegen.