### PR TITLE
Url in der Bestätigungsmail access_request_de ging nicht

### DIFF
--- a/plugins/docs/docs/de_de/main.register.md
+++ b/plugins/docs/docs/de_de/main.register.md
@@ -50,9 +50,11 @@ hidden|termsofuse_accepted|1
 
 ### E-Mail-Template `access_request_de` für die Bestätigung erstellen
 
+Diese E-Mail fordert den Nutzer dazu auf, die Anmeldung zu bestätigen. Der endgültige Link sieht bspw. aus wie folgt: <code>https://www.redaxo.org/anmeldung/bestaetigen/?rex_ycom_activation_key=ACTIVATION_KEY&rex_ycom_id=YCOM_LOGIN</code>
+
 ```
 <?php
-$article_id = 888; // wichtig: hier die Artikel-ID der Bestätigungsseite (register_proof Artikel) eintragen
+$article_id = 999; // Hier die Artikel-ID der Bestätigungsseite eintragen
 
 $article_url = rex_getUrl($article_id,'',array('rex_ycom_activation_key'=>'REX_YFORM_DATA[field=activation_key]','rex_ycom_id'=>'REX_YFORM_DATA[field=email]'));
 $full_url = trim(rex::getServer(),'/').trim($article_url,'.');
@@ -63,8 +65,7 @@ $full_url = trim(rex::getServer(),'/').trim($article_url,'.');
 
 ### Registrierungsbestätigung
 
-
-/* http://redaxo/bestaetigung/?rex_ycom_activation_key=xxxx&rex_ycom_id=yyyy */
+Der Artikel für die Registrierungsbestätigung muss öffentlich zugänglich sein und unter dem Link erreichbar sein, der im o.g. E-Mail-Template angegeben wurde, z.B.: <code>https://www.redaxo.org/anmeldung/bestaetigen/?rex_ycom_activation_key=ACTIVATION_KEY&rex_ycom_id=YCOM_LOGIN</code>
 
 ```
 hidden|status|1

--- a/plugins/docs/docs/de_de/main.register.md
+++ b/plugins/docs/docs/de_de/main.register.md
@@ -51,12 +51,14 @@ hidden|termsofuse_accepted|1
 ### E-Mail-Template `access_request_de` für die Bestätigung erstellen
 
 ```
-<!--
-http://redaxo/bestaetigung/?rex_ycom_activation_key=xxxx&rex_ycom_id=yyyy 
-Bitte die Id (888) durch die Id des register_proof Artikels ersetzen
--->
+<?php
+$article_id = 888; // wichtig: hier die Artikel-ID der Bestätigungsseite (register_proof Artikel) eintragen
+
+$article_url = rex_getUrl($article_id,'',array('rex_ycom_activation_key'=>'REX_YFORM_DATA[field=activation_key]','rex_ycom_id'=>'REX_YFORM_DATA[field=email]'));
+$full_url = trim(rex::getServer(),'/').trim($article_url,'.');
+?>
 <p>Bitte klicken Sie diesen Link, um die Anmeldung zu bestätigen:</p>
-<p><a href="<?= trim(rex::getServer(),'/') . rex_getUrl(888) ?>?rex_ycom_activation_key=REX_YFORM_DATA[field=activation_key]&rex_ycom_id=REX_YFORM_DATA[field=email]"><?= trim(rex::getServer(),'/') . rex_getUrl(888) ?>?rex_ycom_activation_key=REX_YFORM_DATA[field=activation_key]&rex_ycom_id=REX_YFORM_DATA[field=email]</a></p>
+<p><a href="<?=$full_url;?>"><?=$full_url;?></a></p>
 ```
 
 ### Registrierungsbestätigung


### PR DESCRIPTION
1)
Bei mir ging die URL nicht, weil hinter dem neu ./ stand statt nur /
Deswegen ein weiteres trim mit ('.') für rex_getUrl().

https://www.testdomain.de/neu./index.php?article_id=115?rex_ycom_activation_key=..............
https://www.testdomain.de/neu/index.php?article_id=115?rex_ycom_activation_key=..............

2)
Desweiteren hatte ich keine URL-Umschreibung aktiv, also ging das mit dem doppelten ? auch nicht.

in rex_getUrl() hab ich also die Parameter im Array übergeben statt sie mit ? hinten dran zu hängen.