### PR TITLE
404 Fehler bei Mehrsprachen-Multidomain-Umgebung verhindern

### DIFF
--- a/plugins/media_auth/lib/ycom_media_auth_rules.php
+++ b/plugins/media_auth/lib/ycom_media_auth_rules.php
@@ -56,7 +56,13 @@ class rex_ycom_media_auth_rules
                     }
                     exit;
                 }
-                rex_redirect($rule['action']['article_id'], '', ['returnTo' => $_SERVER['REQUEST_URI']]);
+                
+                $clang_id = 1;
+                $yr_domain = rex_sql::factory()->setTable(rex::getTable('yrewrite_domain'))->setWhere('domain LIKE :domain',['domain'=>'%'.$_SERVER['HTTP_HOST'].'%'])->select()->getArray();
+                if (count($yr_domain) == 1) {
+                    $clang_id = $yr_domain[0]['clang_start'];
+                }
+                rex_redirect($rule['action']['article_id'], $clang_id, ['returnTo' => $_SERVER['REQUEST_URI']]);
                 break;
             case 'redirect_wo_returnto':
                 rex_redirect($rule['action']['article_id'], '', []);


### PR DESCRIPTION
Ungepatcht redirected das Plugin immer auf clang_id=1. Das passt aber nicht, wenn für jede Sprache eine eigene Domain eingerichtet wurde.
Der obige Patch veranlasst, dass in diesem Falle auf die richtige Sprache weitergeleitet wird.
Ich gebe zu, dass ich für diesen Code weder ins Guiness Buch komme noch einen Nobelpreis erwarten darf. In meinem Falle löst er aber ein Problem, daher schiebe ich ihn dennoch rüber. Vielleicht findet ihr ja eine elegantere Lösung.