### PR TITLE
Passwort-Platzhalter initial nicht anzeigen

### DIFF
--- a/plugins/auth/lib/yform/value/ycom_auth_password.php
+++ b/plugins/auth/lib/yform/value/ycom_auth_password.php
@@ -23,11 +23,11 @@ class rex_yform_value_ycom_auth_password extends rex_yform_value_abstract
             if ('' != $this->getValue() && !isset($this->params['warning'][$this->getId()])) {
                 $placeholder = rex_i18n::translate('translate:ycom_auth_password_updated');
             }
-        } else {
-            $placeholder = rex_i18n::translate('translate:ycom_auth_password_exists');
             if ('' == $this->getValue()) {
                 $placeholder = rex_i18n::translate('translate:ycom_auth_password_isempty');
             }
+        } else {
+            $placeholder = rex_i18n::translate('translate:ycom_auth_password_exists');
         }
 
         if ('' == $this->getElement('placeholder')) {


### PR DESCRIPTION
Siehe regelmäßige Slack-Diskussionen

(ist ein Vorschlag, vlt. gibt es auch eine bessere Lösung.)