### PR TITLE
rex_response::sendCacheControl() added for every redirect

### DIFF
--- a/plugins/auth/lib/yform/trait_value_auth_extern.php
+++ b/plugins/auth/lib/yform/trait_value_auth_extern.php
@@ -40,6 +40,7 @@ trait rex_yform_trait_value_auth_extern
             return $message;
         }
         if ($this->auth_directLink) {
+            rex_response::sendCacheControl();
             rex_response::sendRedirect(rex_getUrl(rex_config::get('ycom/auth', 'article_id_jump_not_ok')));
         }
         return '';
@@ -96,6 +97,7 @@ trait rex_yform_trait_value_auth_extern
         if (2 == $loginStatus) {
             // already logged in
             rex_ycom_user::updateUser($data);
+            rex_response::sendCacheControl();
             rex_response::sendRedirect($returnTo);
         }
 
@@ -132,6 +134,7 @@ trait rex_yform_trait_value_auth_extern
             return '';
         }
 
+        rex_response::sendCacheControl();
         rex_response::sendRedirect($returnTo);
 
         return '';

--- a/plugins/auth/lib/yform/value/ycom_auth_cas.php
+++ b/plugins/auth/lib/yform/value/ycom_auth_cas.php
@@ -102,6 +102,7 @@ class rex_yform_value_ycom_auth_cas extends rex_yform_value_abstract
         if (2 == $loginStatus) {
             // already logged in
             rex_ycom_user::updateUser($data);
+            rex_response::sendCacheControl();
             \rex_response::sendRedirect($returnTo);
         }
 
@@ -135,6 +136,7 @@ class rex_yform_value_ycom_auth_cas extends rex_yform_value_abstract
             return '';
         }
 
+        rex_response::sendCacheControl();
         \rex_response::sendRedirect($returnTo);
     }
 

--- a/plugins/auth/lib/yform/value/ycom_auth_logout.php
+++ b/plugins/auth/lib/yform/value/ycom_auth_logout.php
@@ -17,6 +17,7 @@ class rex_yform_value_ycom_auth_logout extends rex_yform_value_abstract
             rex_ycom_auth::clearUserSession();
 
             if ('' != $returnTo) {
+                rex_response::sendCacheControl();
                 rex_response::sendRedirect($returnTo);
             }
         }

--- a/plugins/auth/lib/yform/value/ycom_auth_oauth2.php
+++ b/plugins/auth/lib/yform/value/ycom_auth_oauth2.php
@@ -113,6 +113,7 @@ class rex_yform_value_ycom_auth_oauth2 extends rex_yform_value_abstract
                 $authorizationUrl = $provider->getAuthorizationUrl();
                 rex_ycom_auth::setSessionVar('OAUTH2_oauth2state', $provider->getState());
                 rex_ycom_auth::setSessionVar('OAUTH2_oauth2returnTo', $returnTo);
+                rex_response::sendCacheControl();
                 rex_response::sendRedirect($authorizationUrl);
         }
 

--- a/plugins/auth/lib/yform/value/ycom_auth_saml.php
+++ b/plugins/auth/lib/yform/value/ycom_auth_saml.php
@@ -81,6 +81,7 @@ class rex_yform_value_ycom_auth_saml extends rex_yform_value_abstract
                 $ssoBuiltUrl = $auth->login($returnToUrl, [], false, false, true);
                 rex_ycom_auth::setSessionVar('SAML_AuthNRequestID', $auth->getLastRequestID());
                 rex_ycom_auth::setSessionVar('SAML_ssoDate', date('Y-m-d H:i:s'));
+                rex_response::sendCacheControl();
                 rex_response::sendRedirect($ssoBuiltUrl);
                 break;
 
@@ -118,6 +119,7 @@ class rex_yform_value_ycom_auth_saml extends rex_yform_value_abstract
                     $auth->redirectTo($_POST['RelayState']);
                 }
 
+                rex_response::sendCacheControl();
                 rex_redirect(rex_plugin::get('ycom', 'auth')->getConfig('article_id_jump_not_ok'));
                 break;
 
@@ -139,6 +141,7 @@ class rex_yform_value_ycom_auth_saml extends rex_yform_value_abstract
 
                 session_write_close(); // wirklich nötig ?
 
+                rex_response::sendCacheControl();
                 rex_response::sendRedirect($sloBuiltUrl);
                 break;
 
@@ -165,6 +168,7 @@ class rex_yform_value_ycom_auth_saml extends rex_yform_value_abstract
                 if (empty($errors)) {
                     // hier wird davon aufgegangen, dass immer ein returnTo gesetzt ist.
                     // \rex_yrewrite::getFullUrlByArticleId(\rex_plugin::get('ycom', 'auth')->getConfig('article_id_jump_logout'));
+                    rex_response::sendCacheControl();
                     rex_response::sendRedirect($returnTo);
                 } else {
                     if ($this->params['debug']) {
@@ -178,6 +182,7 @@ class rex_yform_value_ycom_auth_saml extends rex_yform_value_abstract
 
         if (0 == count(rex_ycom_auth::getSessionVar('SAML_Userdata', 'array', []))) {
             // direkt durchschleifen zu SAML AUTH .. Hier könnte man auch eine abfrage machen.
+            rex_response::sendCacheControl();
             rex_response::sendRedirect(rex_getUrl('', '', ['rex_ycom_auth_mode' => 'saml', 'rex_ycom_auth_func' => 'sso', 'returnTo' => $returnTo], '&'));
             exit;
         }

--- a/plugins/media_auth/lib/ycom_media_auth_rules.php
+++ b/plugins/media_auth/lib/ycom_media_auth_rules.php
@@ -56,9 +56,11 @@ class rex_ycom_media_auth_rules
                     }
                     exit;
                 }
+                rex_response::sendCacheControl();
                 rex_redirect($rule['action']['article_id'], '', ['returnTo' => $_SERVER['REQUEST_URI']]);
                 break;
             case 'redirect_wo_returnto':
+                rex_response::sendCacheControl();
                 rex_redirect($rule['action']['article_id'], '', []);
                 break;
             case 'header':


### PR DESCRIPTION
Nachdem wir mehrfach Probleme mit dem Browser Cache hatten, haben wir nun einfach bei allen Redirects ein Cache-Control Header mitgeschickt