### PR TITLE
Fehler beim Installieren von 4.0.6 mit der aktuellen yForm Beta

### DIFF
--- a/lib/yform/value/ycom_user.php
+++ b/lib/yform/value/ycom_user.php
@@ -32,7 +32,7 @@ class rex_yform_value_ycom_user extends rex_yform_value_abstract
         }
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'ycom_user -> Beispiel: ycom_user|label|dbfield|Fieldlabel|hidden|[no_db]|showlabel';
     }

--- a/lib/yform/value/ycom_user_init.php
+++ b/lib/yform/value/ycom_user_init.php
@@ -12,7 +12,7 @@ class rex_yform_value_ycom_user_init extends rex_yform_value_abstract
         }
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'ycom_user_init -> Beispiel: ycom_user_init|[label]|[name]|error_msg';
     }

--- a/plugins/auth/lib/yform/action/ycom_auth_db.php
+++ b/plugins/auth/lib/yform/action/ycom_auth_db.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 class rex_yform_action_ycom_auth_db extends rex_yform_action_db
 {
-    public function executeAction()
+    public function executeAction(): void
     {
         /** @var rex_ycom_user $user */
         $user = rex_ycom_auth::getUser();
@@ -12,7 +12,7 @@ class rex_yform_action_ycom_auth_db extends rex_yform_action_db
         if (rex::isBackend() || !$user) {
             echo 'error - access denied - user not logged in';
 
-            return false;
+            return;
         }
 
         $action = $this->getElement(2);
@@ -31,11 +31,11 @@ class rex_yform_action_ycom_auth_db extends rex_yform_action_db
                 $this->setElement(2, '');
                 $this->setElement(3, 'main_where');
 
-                return parent::executeAction();
+                parent::executeAction();
         }
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'action|ycom_auth_db|update(default)/delete';
     }

--- a/plugins/auth/lib/yform/validate/ycom_auth.php
+++ b/plugins/auth/lib/yform/validate/ycom_auth.php
@@ -59,7 +59,7 @@ class rex_yform_validate_ycom_auth extends rex_yform_validate_abstract
         }
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'ycom_auth -> prüft ob login und registriert user, beispiel: validate|ycom_auth|loginfield|passwordfield|stayfield|warning_message_enterloginpsw|warning_message_login_failed';
     }

--- a/plugins/auth/lib/yform/validate/ycom_auth_login.php
+++ b/plugins/auth/lib/yform/validate/ycom_auth_login.php
@@ -50,7 +50,7 @@ class rex_yform_validate_ycom_auth_login extends rex_yform_validate_abstract
         }
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'ycom_auth_login -> prüft ob leer, beispiel: validate|ycom_auth_login|label1=request1,label2=request2|status>0|warning_message|opt:load_field1,load_field2,load_field3|[no_db] ';
     }

--- a/plugins/auth/lib/yform/validate/ycom_auth_password.php
+++ b/plugins/auth/lib/yform/validate/ycom_auth_password.php
@@ -21,7 +21,7 @@ class rex_yform_validate_ycom_auth_password extends rex_yform_validate_abstract
         }
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'ycom_auth_password -> validate|ycom_auth_password|pswfield|warning_message';
     }

--- a/plugins/auth/lib/yform/value/ycom_auth_cas.php
+++ b/plugins/auth/lib/yform/value/ycom_auth_cas.php
@@ -138,7 +138,7 @@ class rex_yform_value_ycom_auth_cas extends rex_yform_value_abstract
         \rex_response::sendRedirect($returnTo);
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'ycom_auth_cas|label|error_msg|[allowed returnTo domains: DomainA,DomainB]|[default Userdata as Json{"ycom_groups": 3, "termsofuse_accepted": 1}]';
     }

--- a/plugins/auth/lib/yform/value/ycom_auth_load_user.php
+++ b/plugins/auth/lib/yform/value/ycom_auth_load_user.php
@@ -19,7 +19,7 @@ class rex_yform_value_ycom_auth_load_user extends rex_yform_value_abstract
         }
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'ycom_auth_load_user -> Beispiel: ycom_auth_load_user|label|opt:field1,field2,field3';
     }

--- a/plugins/auth/lib/yform/value/ycom_auth_logout.php
+++ b/plugins/auth/lib/yform/value/ycom_auth_logout.php
@@ -22,7 +22,7 @@ class rex_yform_value_ycom_auth_logout extends rex_yform_value_abstract
         }
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'ycom_auth_logout -> Beispiel: ycom_auth_logout|label|[allowed domains: DomainA,DomainB]|[returnTo]';
     }

--- a/plugins/auth/lib/yform/value/ycom_auth_oauth2.php
+++ b/plugins/auth/lib/yform/value/ycom_auth_oauth2.php
@@ -119,7 +119,7 @@ class rex_yform_value_ycom_auth_oauth2 extends rex_yform_value_abstract
         return $this->auth_createOrUpdateYComUser($Userdata, $returnTo);
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'ycom_auth_oauth2|label|error_msg|[allowed returnTo domains: DomainA,DomainB]|default Userdata as Json{"ycom_groups": 3, "termsofuse_accepted": 1}|direct_link 0,1';
     }

--- a/plugins/auth/lib/yform/value/ycom_auth_password.php
+++ b/plugins/auth/lib/yform/value/ycom_auth_password.php
@@ -21,7 +21,7 @@ class rex_yform_value_ycom_auth_password extends rex_yform_value_abstract
         $this->params['form_output'][$this->getId()] = $this->parse(['value.ycom_password.tpl.php', 'value.password.tpl.php', 'value.text.tpl.php'], ['type' => 'password', 'value' => '', 'script' => $this->getElement('script'), 'rules' => $rules]);
     }
 
-    public function preAction()
+    public function preAction(): void
     {
         $password = '';
         $hashed_value = '';
@@ -54,12 +54,12 @@ class rex_yform_value_ycom_auth_password extends rex_yform_value_abstract
         $this->params['value_pool']['email'][$this->getName()] = $password;
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'ycom_auth_password -> Beispiel: ycom_auth_password|name|label|[password-rules-as-json]|message|[script 0/1]';
     }
 
-    public function getDefinitions()
+    public function getDefinitions(): array
     {
         return [
             'type' => 'value',

--- a/plugins/auth/lib/yform/value/ycom_auth_returnto.php
+++ b/plugins/auth/lib/yform/value/ycom_auth_returnto.php
@@ -29,7 +29,7 @@ class rex_yform_value_ycom_auth_returnto extends rex_yform_value_abstract
         $this->params['value_pool']['email'][$this->getName()] = $this->getValue();
     }
 
-    public function executeAction()
+    public function executeAction(): void
     {
         if ('' != $this->getValue()) {
             header('Location: ' . $this->getValue());
@@ -37,7 +37,7 @@ class rex_yform_value_ycom_auth_returnto extends rex_yform_value_abstract
         }
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'ycom_auth_returnto|label|[allowed domains: DomainA,DomainB]|[URL]';
     }

--- a/plugins/auth/lib/yform/value/ycom_auth_saml.php
+++ b/plugins/auth/lib/yform/value/ycom_auth_saml.php
@@ -187,7 +187,7 @@ class rex_yform_value_ycom_auth_saml extends rex_yform_value_abstract
         return $this->auth_createOrUpdateYComUser($Userdata, $returnTo);
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'ycom_auth_saml|label|error_msg|[allowed returnTo domains: DomainA,DomainB]|default Userdata as Json{"ycom_groups": 3, "termsofuse_accepted": 1}|direct_link 0,1';
     }


### PR DESCRIPTION


![Zwischenablage-1](https://user-images.githubusercontent.com/1277494/144596967-6781a448-e378-4ade-991f-ef6436b19ed2.jpg)

Lösung:
Added missing return types in ycom_auth_password value