### PR TITLE
Require REDAXO 5.12.0

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -21,7 +21,7 @@ requires:
         yform: '>=3.3.1'
         yrewrite: '>=2.6'
         phpmailer: '>=2.2'
-    redaxo: '^5.8'
+    redaxo: '^5.12.0'
 
 system_plugins:
     - auth


### PR DESCRIPTION
`rex_file::require` kommt erst mit REDAXO 5.12.0
https://github.com/yakamara/redaxo_ycom/blob/a555a17b11573cae6e815ac252e54e25cb5fefba/pages/docs.php#L34