### PR TITLE
Benutzereinstellungen beim Update nicht überschreiben

### DIFF
--- a/plugins/auth/install.php
+++ b/plugins/auth/install.php
@@ -5,9 +5,16 @@
  * @psalm-scope-this rex_addon
  */
 
-rex_config::set('ycom/auth', 'auth_cookie_ttl', '14');
-rex_config::set('ycom/auth', 'auth_rule', 'login_try_5_pause');
-rex_config::set('ycom/auth', 'login_field', 'email');
+// Set default settings
+if(!rex_config::has('ycom/auth', 'auth_cookie_ttl')) {
+    rex_config::set('ycom/auth', 'auth_cookie_ttl', '14');
+}
+if(!rex_config::has('ycom/auth', 'auth_rule')) {
+    rex_config::set('ycom/auth', 'auth_rule', 'login_try_5_pause');
+}
+if(!rex_config::has('ycom/auth', 'login_field')) {
+    rex_config::set('ycom/auth', 'login_field', 'email');
+}
 
 // Update from Version < 4
 $articleAuthTypeWasEnum = false;

--- a/plugins/auth/install.php
+++ b/plugins/auth/install.php
@@ -5,17 +5,6 @@
  * @psalm-scope-this rex_addon
  */
 
-// Set default settings
-if(!rex_config::has('ycom/auth', 'auth_cookie_ttl')) {
-    rex_config::set('ycom/auth', 'auth_cookie_ttl', '14');
-}
-if(!rex_config::has('ycom/auth', 'auth_rule')) {
-    rex_config::set('ycom/auth', 'auth_rule', 'login_try_5_pause');
-}
-if(!rex_config::has('ycom/auth', 'login_field')) {
-    rex_config::set('ycom/auth', 'login_field', 'email');
-}
-
 // Update from Version < 4
 $articleAuthTypeWasEnum = false;
 $articleTable = rex_sql_table::get(rex::getTable('article'));

--- a/plugins/auth/package.yml
+++ b/plugins/auth/package.yml
@@ -10,3 +10,8 @@ page:
     hidden: false
     subpages:
         settings: { title: 'translate:ycom_auth_settings'}
+
+default_config:
+    auth_cookie_ttl: '14'
+    auth_rule: 'login_try_5_pause'
+    login_field: 'email'


### PR DESCRIPTION
Bisher wurden Benutzereinstellungen beim Update überschrieben. Dieses Patch behebt den Fehler.