### PR TITLE
json_decode fix

### DIFF
--- a/plugins/auth/lib/yform/value/ycom_auth_password.php
+++ b/plugins/auth/lib/yform/value/ycom_auth_password.php
@@ -4,7 +4,7 @@ class rex_yform_value_ycom_auth_password extends rex_yform_value_abstract
 {
     public function enterObject()
     {
-        $rules = json_decode($this->getElement('rules'), true);
+        $rules = (is_array($this->getElement('rules')) ? $this->getElement('rules') : json_decode($this->getElement('rules'), true));
         if (!$rules || 0 == count($rules)) {
             $rules = json_decode(rex_yform_validate_password_policy::PASSWORD_POLICY_DEFAULT_RULES, true);
         }


### PR DESCRIPTION
json_decode erzeugt NULL wenn das value selbst schon ein Array ist (bei Nutzung von YForm in PHP-Schreibweise)