### PR TITLE
Give login status flags a name

### DIFF
--- a/plugins/auth/lib/yform/trait_value_auth_extern.php
+++ b/plugins/auth/lib/yform/trait_value_auth_extern.php
@@ -104,7 +104,7 @@ trait rex_yform_trait_value_auth_extern
         ];
 
         $loginStatus = rex_ycom_auth::login($params);
-        if (2 == $loginStatus) {
+        if (rex_ycom_auth::STATUS_HAS_LOGGED_IN == $loginStatus) {
             // already logged in
             rex_ycom_user::updateUser($data);
             rex_response::sendCacheControl();
@@ -134,7 +134,7 @@ trait rex_yform_trait_value_auth_extern
         $params['ignorePassword'] = true;
         $loginStatus = rex_ycom_auth::login($params);
 
-        if (2 != $loginStatus) {
+        if (rex_ycom_auth::STATUS_HAS_LOGGED_IN != $loginStatus) {
             if ($this->params['debug']) {
                 dump($loginStatus);
                 dump($user);

--- a/plugins/auth/lib/yform/validate/ycom_auth.php
+++ b/plugins/auth/lib/yform/validate/ycom_auth.php
@@ -52,7 +52,7 @@ class rex_yform_validate_ycom_auth extends rex_yform_validate_abstract
         ];
         $status = rex_ycom_auth::login($params);
 
-        if (2 != $status) {
+        if (rex_ycom_auth::STATUS_HAS_LOGGED_IN != $status) {
             foreach ($warningObjects as $warningObject) {
                 $this->params['warning'][$warningObject->getId()] = $this->params['error_class'];
                 $this->params['warning_messages'][$warningObject->getId()] = $this->getElement(6);

--- a/plugins/auth/lib/yform/value/ycom_auth_cas.php
+++ b/plugins/auth/lib/yform/value/ycom_auth_cas.php
@@ -114,7 +114,7 @@ class rex_yform_value_ycom_auth_cas extends rex_yform_value_abstract
         $params['ignorePassword'] = true;
 
         $loginStatus = \rex_ycom_auth::login($params);
-        if (2 == $loginStatus) {
+        if (rex_ycom_auth::STATUS_HAS_LOGGED_IN == $loginStatus) {
             // already logged in
             rex_ycom_user::updateUser($data);
             rex_response::sendCacheControl();
@@ -142,7 +142,7 @@ class rex_yform_value_ycom_auth_cas extends rex_yform_value_abstract
         $params['ignorePassword'] = true;
         $loginStatus = \rex_ycom_auth::login($params);
 
-        if (2 != $loginStatus) {
+        if (rex_ycom_auth::STATUS_HAS_LOGGED_IN != $loginStatus) {
             if ($this->params['debug']) {
                 dump($loginStatus);
                 dump($user);


### PR DESCRIPTION
Document status flags with names, provide PHPdoc for the return type and the structure of the $params array.
Use named status flags for validation checks.